### PR TITLE
Fixed: the function copy could panic if the goroutine execution start…

### DIFF
--- a/scp.go
+++ b/scp.go
@@ -38,6 +38,7 @@ func copy(size int64, mode os.FileMode, fileName string, contents io.Reader, des
 
 	cmd := fmt.Sprintf("scp -t %s", destination)
 	if err := session.Start(cmd); err != nil {
+		w.Close()
 		return err
 	}
 

--- a/scp.go
+++ b/scp.go
@@ -30,9 +30,13 @@ func CopyPath(filePath, destinationPath string, session *ssh.Session) error {
 
 func copy(size int64, mode os.FileMode, fileName string, contents io.Reader, destination string, session *ssh.Session) error {
 	defer session.Close()
+	w, err := session.StdinPipe()
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
 	go func() {
-		w, _ := session.StdinPipe()
-		defer w.Close()
 		fmt.Fprintf(w, "C%#o %d %s\n", mode, size, fileName)
 		io.Copy(w, contents)
 		fmt.Fprint(w, "\x00")

--- a/scp.go
+++ b/scp.go
@@ -31,19 +31,26 @@ func CopyPath(filePath, destinationPath string, session *ssh.Session) error {
 func copy(size int64, mode os.FileMode, fileName string, contents io.Reader, destination string, session *ssh.Session) error {
 	defer session.Close()
 	w, err := session.StdinPipe()
+
 	if err != nil {
 		return err
 	}
-	defer w.Close()
 
-	go func() {
-		fmt.Fprintf(w, "C%#o %d %s\n", mode, size, fileName)
-		io.Copy(w, contents)
-		fmt.Fprint(w, "\x00")
-	}()
 	cmd := fmt.Sprintf("scp -t %s", destination)
-	if err := session.Run(cmd); err != nil {
+	if err := session.Start(cmd); err != nil {
 		return err
 	}
-	return nil
+
+	errors := make(chan error)
+
+	go func() {
+		errors <- session.Wait()
+	}()
+
+	fmt.Fprintf(w, "C%#o %d %s\n", mode, size, fileName)
+	io.Copy(w, contents)
+	fmt.Fprint(w, "\x00")
+	w.Close()
+
+	return <-errors
 }


### PR DESCRIPTION
…s after the session run method. It could happen before stdin needs to be init before the run of the session. In this pr, we make sure to init the stdin before the run of the session